### PR TITLE
Fix possible fix(deps): 4 vulnerable dependencies in requirements.txt

### DIFF
--- a/src/lollms_client/tts_bindings/FishSpeech/requirements.txt
+++ b/src/lollms_client/tts_bindings/FishSpeech/requirements.txt
@@ -8,7 +8,7 @@ git+https://github.com/fishaudio/fish-speech.git
 # Server
 fastapi==0.109.0
 uvicorn==0.27.0
-python-multipart==0.0.9
+python-multipart==0.0.30
 
 # Audio processing
 numpy<2.0.0


### PR DESCRIPTION
This changes `src/lollms_client/tts_bindings/FishSpeech/requirements.txt` to address something a scan flagged. It is around line 11.

Vulnerability: CVE-2024-53981 (HIGH) affects python-multipart 0.0.9, pinned in src/lollms_client/tts_bindings/FishSpeech/requirements.txt (line 11). python-multipart is a streaming multipart/form-data parser commonly used by FastAPI/Starlette for file uploads. In vulnerable versions, the parser skips line breaks before the first boundary and any trailing bytes after the last boundary one byte at a time, emitting a log event for each byte. An attacker can send a crafted multipart request containing large amounts of data before the first or after the last boundary, causing excessive logging and high CPU load that stalls the processing thread. In an ASGI application this can block the event loop and prevent other requests from being served, resulting in a remote, unauthenticated denial of service (DoS). Risk is HIGH because TTS binding endpoints that accept multipart uploads (e.g., audio file posts) are directly exposed to this attack vector. Fix: upgrade python-multipart to >= 0.0.18, where per-byte boundary parsing/logging no longer occurs.

Upgrade python-multipart from 0.0.9 to 0.0.30 to address four known CVE advisories.

For reference: rule `CVE-2024-53981`. Rated high.

Take or leave whichever parts are useful. If this is not the right approach, closing is fine.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
